### PR TITLE
New enum for item status

### DIFF
--- a/Model/Enums/ApprovalState.cs
+++ b/Model/Enums/ApprovalState.cs
@@ -13,12 +13,36 @@ namespace Maximiz.Model.Enums
     [JsonConverter(typeof(StringEnumConverter))]
     public enum ApprovalState
     {
+        /// <summary>
+        /// Used as a default if we don't know the state.
+        /// </summary>
         [EnumMember(Value = "unknown")]
         Unknown,
+
+        /// <summary>
+        /// Used when the Backend requests the creation of
+        /// an item in our own database. This is the state
+        /// before the Poller has acutally created said item.
+        /// </summary>
+        [EnumMember(Value = "submitted")]
+        Submitted,
+
+        /// <summary>
+        /// Item exists externally and is approved.
+        /// </summary>
         [EnumMember(Value = "approved")]
         Approved,
+
+        /// <summary>
+        /// Item exists externally but has not yet been 
+        /// approved.
+        /// </summary>
         [EnumMember(Value = "pending")]
         Pending,
+
+        /// <summary>
+        /// Item has been rejected externally.
+        /// </summary>
         [EnumMember(Value = "rejected")]
         Rejected,
     }

--- a/Poller/Poller.Taboola/TaboolaPollerHttp.cs
+++ b/Poller/Poller.Taboola/TaboolaPollerHttp.cs
@@ -114,7 +114,7 @@ namespace Poller.Taboola
 
         /// <summary>
         /// Run the remote query and catch all exceptions 
-        /// where before letting them propagate upwards.
+        /// before letting them propagate upwards.
         /// </summary>
         /// <typeparam name="TResult"></typeparam>
         /// <param name="method">HTTP method.</param>


### PR DESCRIPTION
We need a status in the enum for the approval state of items for the case where we have requested the external creation in the backend.